### PR TITLE
CONT-110: AbstractSessionLogsExtractor always uses the highest callab…

### DIFF
--- a/continuity.session.logs/src/main/java/org/continuity/session/logs/extractor/AbstractSessionLogsExtractor.java
+++ b/continuity.session.logs/src/main/java/org/continuity/session/logs/extractor/AbstractSessionLogsExtractor.java
@@ -147,7 +147,7 @@ public abstract class AbstractSessionLogsExtractor<T> {
 
 		params.putAll(extractUriParams(uri, abstractUri));
 
-		if (httpRequest.getRequestBody().isPresent()) {
+		if (httpRequest.getRequestBody().isPresent() && !httpRequest.getRequestBody().get().isEmpty()) {
 			params.put("_BODY", new String[] { httpRequest.getRequestBody().get() });
 		}
 

--- a/continuity.session.logs/src/main/java/org/continuity/session/logs/extractor/OPENxtraceSessionLogsExtractor.java
+++ b/continuity.session.logs/src/main/java/org/continuity/session/logs/extractor/OPENxtraceSessionLogsExtractor.java
@@ -131,7 +131,7 @@ public class OPENxtraceSessionLogsExtractor extends AbstractSessionLogsExtractor
 			while (!callables.isEmpty()) {
 				Callable currentCallable = callables.poll();
 				if (currentCallable instanceof HTTPRequestProcessingImpl) {
-					httpRequestProcessingCallables.add((HTTPRequestProcessingImpl) callable);
+					httpRequestProcessingCallables.add((HTTPRequestProcessingImpl) currentCallable);
 				} else if (currentCallable instanceof NestingCallable && httpRequestProcessingCallables.isEmpty()) {
 					callables.addAll(((NestingCallable) currentCallable).getCallees());
 				} else if (currentCallable instanceof RemoteInvocationImpl && ((RemoteInvocationImpl) currentCallable).getTargetSubTrace().isPresent()


### PR DESCRIPTION
…le in the CallTree & CONT-111: Empty Body Paramter is stored in the Session logs