### PR TITLE
 CONT-168: Session Logs service assumes Callable identifier to be long

### DIFF
--- a/continuity.session.logs/src/main/java/org/continuity/session/logs/extractor/OPENxtraceHttpRequestData.java
+++ b/continuity.session.logs/src/main/java/org/continuity/session/logs/extractor/OPENxtraceHttpRequestData.java
@@ -3,6 +3,7 @@ package org.continuity.session.logs.extractor;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.spec.research.open.xtrace.api.core.callables.HTTPRequestProcessing;
 import org.spec.research.open.xtrace.dflt.impl.core.callables.HTTPRequestProcessingImpl;
 
@@ -26,12 +27,26 @@ public class OPENxtraceHttpRequestData implements HTTPRequestData {
 
 	@Override
 	public long getIdentifier() {
-		return (Long) callable.getIdentifier().get();
+		long identifier;
+		
+		if(callable.getIdentifier().get() instanceof String) {
+			String stringIdentifier = (String) callable.getIdentifier().get();
+			if(StringUtils.isNumeric(stringIdentifier)) {
+				identifier = Long.parseLong(stringIdentifier);
+			} else if(stringIdentifier.matches("[0-9a-fA-F]+")) {
+				identifier = Long.parseLong(stringIdentifier, 16);
+			} else {
+				identifier = (long) callable.getIdentifier().get().hashCode();
+			}
+		} else {
+			identifier = (long) callable.getIdentifier().get().hashCode();
+		}
+		return identifier;
 	}
 
 	@Override
 	public long getTimestamp() {
-		return callable.getTimestamp()*1000000;
+		return callable.getTimestamp() * 1000000;
 	}
 
 	@Override


### PR DESCRIPTION
@Henning-Schulz 